### PR TITLE
Control HTML of linkified URLs in text

### DIFF
--- a/autocorrect/plugin.js
+++ b/autocorrect/plugin.js
@@ -460,8 +460,12 @@
 
 				beforeReplace();
 				var bookmark = cursor.createBookmark();
-				var attributes = {'data-cke-saved-href': href, href: href};
-				var style = new CKEDITOR.style({ element: 'a', attributes: attributes } );
+				//use config to control HTML of linkified text
+				if(config.autocorrect_recognizeUrlsTagAttribs=='href')
+					var attributes = {'data-cke-saved-href': href, href: href};
+				else
+					var attributes=config.autocorrect_recognizeUrlsTagAttribs;
+				var style = new CKEDITOR.style({ element: config.autocorrect_recognizeUrlsTag, attributes: attributes } );
 				style.type = CKEDITOR.STYLE_INLINE; // need to override... dunno why.
 				style.applyToRange( matchRange );
 				cursor.moveToBookmark(bookmark);
@@ -851,6 +855,9 @@ CKEDITOR.config.autocorrect_replacementTable = {"-->": "→", "-+": "∓", "->":
 CKEDITOR.config.autocorrect_useReplacementTable = true;
 
 CKEDITOR.config.autocorrect_recognizeUrls = true;
+//Control HTML of linkified URLs in text
+CKEDITOR.config.autocorrect_recognizeUrlsTag = 'a';
+CKEDITOR.config.autocorrect_recognizeUrlsTagAttribs = 'href';
 // language specific
 CKEDITOR.config.autocorrect_dash = '–';
 


### PR DESCRIPTION
My attempt at solving #9

Added options to control the HTML used to linkify typed urls.

Defaults to `<a href="http://yahoo.com" data-cke-saved-href="http://yahoo.com">http://yahoo.com</a>` -- can be changed, e.g., to `<span class="url">http://yahoo.com</span>` with the following in CKEDITOR's config file:

```
config.autocorrect_recognizeUrlsTag = 'span';
config.autocorrect_recognizeUrlsTagAttribs = {'class': 'url'};
```

Margic value of `url` for `autocorrect_recognizeUrlsTagAttribs` results in default linkified attributes...
