### PR TITLE
ensure user agent supports localStorage

### DIFF
--- a/autocorrect/plugin.js
+++ b/autocorrect/plugin.js
@@ -7,8 +7,13 @@
  */
 
 (function() {
-	var localStorage = window.localStorage;
-	if (!localStorage) {
+	var storageTest = 'autocorrectplugin'
+	var localStorage = null;
+	try {
+		localStorage = window.localStorage;
+		localStorage.setItem(storageTest, storageTest)
+		localStorage.getItem(storageTest)
+	} catch(e) {
 		localStorage = {
 			getItem: function(key) {
 				return null;

--- a/autocorrect/plugin.js
+++ b/autocorrect/plugin.js
@@ -12,7 +12,7 @@
 	try {
 		localStorage = window.localStorage;
 		localStorage.setItem(storageTest, storageTest)
-		localStorage.getItem(storageTest)
+		localStorage.removeItem(storageTest)
 	} catch(e) {
 		localStorage = {
 			getItem: function(key) {
@@ -961,7 +961,7 @@
 
 
 /**
- * 
+ *
  *
  * @cfg
  * @member CKEDITOR.config

--- a/autocorrect/plugin.js
+++ b/autocorrect/plugin.js
@@ -961,7 +961,7 @@
 
 
 /**
- *
+ * 
  *
  * @cfg
  * @member CKEDITOR.config


### PR DESCRIPTION
Hi There.

We're getting reports from errorception of "SecurityError: DOM Exception 18: An attempt was made to break through the security policy of the user agent."  I believe this is due to the default security policy of some user agents and can be circumvented by use of a try/catch block around usage of localStorage.

Thanks!
