### PR TITLE
add: compatibility with French « quotes with whitespace padding »

### DIFF
--- a/autocorrect/plugin.js
+++ b/autocorrect/plugin.js
@@ -801,7 +801,14 @@
 
 				var leftChar = iterator.previousCharacter();
 
-				var isClosingQuote = leftChar ? '  –—([{'.indexOf(leftChar) < 0 : false;
+				var startMatches = quoteRange.startContainer.$.wholeText.match(new RegExp(quotes[0], 'g'));
+				var endMatches = quoteRange.startContainer.$.wholeText.match(new RegExp(quotes[1], 'g'));
+
+				var startQuoteCount = startMatches ? startMatches.length : 0;
+				var endQuoteCount = endMatches ? endMatches.length : 0;
+
+				var isClosingQuote = leftChar ? ('  –—([{'.indexOf(leftChar) < 0 || (startQuoteCount > 0 && startQuoteCount !== endQuoteCount))  : false;
+
 				var replacement = quotes[Number(isClosingQuote)];
 
 				beforeReplace();
@@ -956,7 +963,7 @@
 
 
 /**
- * 
+ *
  *
  * @cfg
  * @member CKEDITOR.config


### PR DESCRIPTION
The current system for checking whether to insert an opening or closing smart quote is robust and functional for languages like English where quote marks are normally written with no intervening whitespace between the marks themselves and the text they englobe. 

Example: "the quotes touch the text"

In French however, the custom is to insert a single space between each quote mark.

Example: « the quotes do not touch the text »

---

The current state of the autocorrect plugin does not allow for this desired outcome. I have added code which remains compatible with languages like English and "quotes without whitespace", but that is also compatible with French quotes « like this ».
