### PR TITLE
Add package.json for publishing to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "ckeditor-autocorrect-plugin",
+  "version": "1.0.0",
+  "description": "AutoCorrect plugin for CKEditor",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/danyaPostfactum/ckeditor-autocorrect-plugin.git"
+  },
+  "author": "danyaPostfactum",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/danyaPostfactum/ckeditor-autocorrect-plugin/issues"
+  },
+  "homepage": "https://github.com/danyaPostfactum/ckeditor-autocorrect-plugin#readme"
+}


### PR DESCRIPTION
It will be very useful if you publish this plugin to npm or at least add package.json to the repository, so we can install it straight from github