### PR TITLE
added german and french translations according to MSWord

### DIFF
--- a/autocorrect/dialogs/options.js
+++ b/autocorrect/dialogs/options.js
@@ -19,7 +19,7 @@
 		return {
 				title: lang.autocorrect,
 				resizable: CKEDITOR.DIALOG_RESIZE_NONE,
-				minWidth: 350,
+				minWidth: 450,
 				minHeight: 170,
 				onOk: function() {
 					this.commitContent();

--- a/autocorrect/lang/de-ch.js
+++ b/autocorrect/lang/de-ch.js
@@ -1,0 +1,23 @@
+CKEDITOR.plugins.setLang( 'autocorrect', 'de-ch', {
+	toolbar: 'AutoKorrektur',
+	autocorrect: 'AutoKorrektur',
+	disable: 'AutoKorrektur deaktivieren',
+	enable: 'AutoKorrektur aktivieren',
+	autocorrectNow: 'AutoKorrektur jetzt starten',
+	options: 'AutoKorrektur-Einstellungen',
+	autoformat: 'AutoFormat',
+	autoformatAsYouType: 'AutoFormat während der Eingabe',
+	replaceTextAsYouType: 'Text während der Eingabe ersetzen',
+	replaceAsYouType: 'Während der Eingabe automatisch formatieren',
+	applyAsYouType: 'Während der Eingabe ersetzen',
+	apply: 'ersetzen',
+	replace: 'formatieren',
+	smartQuotesOption: '"Gerade" Anführungszeichen durch «typographische»',
+	formatOrdinalsOption: 'Englische Ordnungszahlen (1st) hochstellen',
+	replaceHyphensOption: 'Bindestriche (--) durch Geviertstrich (—)',
+	recognizeUrlsOption: 'Internet- und Netzwerkpfade durch Links',
+	formatBulletedListsOption: 'Automatische Aufzählung',
+	formatNumberedListsOption: 'Automatische Nummerierung',
+	createHorizontalRulesOption: 'Rahmenlinien',
+	replaceFractionsOption: 'Bruchzahlen (1/2) durch Sonderzeichen (½)'
+});

--- a/autocorrect/lang/de.js
+++ b/autocorrect/lang/de.js
@@ -1,0 +1,23 @@
+CKEDITOR.plugins.setLang( 'autocorrect', 'de', {
+	toolbar: 'AutoKorrektur',
+	autocorrect: 'AutoKorrektur',
+	disable: 'AutoKorrektur deaktivieren',
+	enable: 'AutoKorrektur aktivieren',
+	autocorrectNow: 'AutoKorrektur jetzt starten',
+	options: 'AutoKorrektur-Einstellungen',
+	autoformat: 'AutoFormat',
+	autoformatAsYouType: 'AutoFormat während der Eingabe',
+	replaceTextAsYouType: 'Text während der Eingabe ersetzen',
+	replaceAsYouType: 'Während der Eingabe automatisch formatieren',
+	applyAsYouType: 'Während der Eingabe ersetzen',
+	apply: 'ersetzen',
+	replace: 'formatieren',
+	smartQuotesOption: '"Gerade" Anführungszeichen durch “typographische”',
+	formatOrdinalsOption: 'Englische Ordnungszahlen (1st) hochstellen',
+	replaceHyphensOption: 'Bindestriche (--) durch Geviertstrich (—)',
+	recognizeUrlsOption: 'Internet- und Netzwerkpfade durch Links',
+	formatBulletedListsOption: 'Automatische Aufzählung',
+	formatNumberedListsOption: 'Automatische Nummerierung',
+	createHorizontalRulesOption: 'Rahmenlinien',
+	replaceFractionsOption: 'Bruchzahlen (1/2) durch Sonderzeichen (½)'
+});

--- a/autocorrect/lang/fr.js
+++ b/autocorrect/lang/fr.js
@@ -1,0 +1,23 @@
+CKEDITOR.plugins.setLang( 'autocorrect', 'fr', {
+	toolbar: 'Autocorrection',
+	autocorrect: 'Correction automatique',
+	disable: 'Désactiver l’autocorrection',
+	enable: 'Activer l’autocorrection',
+	autocorrectNow: 'Démarrer l’autocorrection',
+	options: 'Options de correction automatique',
+	autoformat: 'AutoFormat',
+	autoformatAsYouType: 'Mise en forme automatique',
+	replaceTextAsYouType: 'Remplacer au cours de la frappe',
+	replaceAsYouType: 'Mise en forme automatique au cours de la frappe',
+	applyAsYouType: 'Remplace au cours de la frappe',
+	apply: 'remplacer',
+	replace: 'mise en forme',
+	smartQuotesOption: 'Les guillemets "pairs" par «typographique»',
+	formatOrdinalsOption: 'Ordinaux (1er) en exposant',
+	replaceHyphensOption: 'Traits d’union (--) avec tiret demi-cadratien (—)',
+	recognizeUrlsOption: 'Adresses Internet et réseau par des liens hypertexte',
+	formatBulletedListsOption: 'Liste à puces automatiques',
+	formatNumberedListsOption: 'Listes numérotées automatiques',
+	createHorizontalRulesOption: 'Bordures',
+	replaceFractionsOption: 'Fractions (1/2) par caractère de fraction (½)'
+});

--- a/autocorrect/plugin.js
+++ b/autocorrect/plugin.js
@@ -102,7 +102,7 @@
 
 	CKEDITOR.plugins.add( 'autocorrect', {
 		requires: 'menubutton',
-		lang: 'en,ru',
+		lang: 'de,fr,en,ru',
 		icons: 'autocorrect', // %REMOVE_LINE_CORE%
 		hidpi: true, // %REMOVE_LINE_CORE%
 		init: function( editor ) {

--- a/autocorrect/plugin.js
+++ b/autocorrect/plugin.js
@@ -102,7 +102,7 @@
 
 	CKEDITOR.plugins.add( 'autocorrect', {
 		requires: 'menubutton',
-		lang: 'de,fr,en,ru',
+		lang: 'de,de-ch,fr,en,ru',
 		icons: 'autocorrect', // %REMOVE_LINE_CORE%
 		hidpi: true, // %REMOVE_LINE_CORE%
 		init: function( editor ) {


### PR DESCRIPTION
German and french translations are added according to UI in MSWord. There's a difference for apply and replace in relation to the options we have in code. I've translated them according to Word and not as they are used in english translation in the plugin.